### PR TITLE
Added a check for if the portal is marked as closed, allowing windows to import correctly

### DIFF
--- a/ddimport.js
+++ b/ddimport.js
@@ -321,7 +321,8 @@ class DDImporter {
             (door.bounds[1].x * file.resolution.pixels_per_grid) + offsetX,
             (door.bounds[1].y * file.resolution.pixels_per_grid) + offsetY
           ],
-          door: true
+          door: true,
+          sense: door.closed?1:0
         }).data)
     }
 

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "dd-import",
   "title": "DungeonDraft Importer",
   "description": "Imports scene elements from Dungeon Draft map files",
-  "version": "0.9",
+  "version": "0.90",
   "author": "Moo Man, m42e",
   "scripts": ["./ddimport.js"],
   "styles": ["./styles.css"],


### PR DESCRIPTION
This is a one-line change, not really much of a pull request. 

Dungeondraft does not differentiate between movement/sight blocking for portals, however, setting "block light" to false, exports as "door.closed: false"
Alternatively, you could just import them as open doors, which would be more true to the format  (then it's just  ds: door.closed?0:1), but I feel like it's more useful to mark windows 