### PR TITLE
Add support for image resizing and customizing grid size on import

### DIFF
--- a/ddimport.js
+++ b/ddimport.js
@@ -255,7 +255,7 @@ class DDImporter extends Application
             ui.notifications.notify("Combining " + (fidx + 1) + " out of " + files.length)
             let f = files[fidx];
             image_type = DDImporter.getImageType(atob(f.image.substr(0,8)));
-            await DDImporter.image2Canvas(mycanvas, f, image_type)
+            await DDImporter.image2Canvas(mycanvas, f, image_type, size.x, size.y)
           }
           ui.notifications.notify("Uploading image ....")
           if (toWebp){
@@ -442,12 +442,12 @@ class DDImporter extends Application
       image.decoding = 'sync';
       image.addEventListener('load', function() {
           image.decode().then(() => {
-            canvas.drawImage(image, file.pos_in_image.x, file.pos_in_image.y);
+            canvas.drawImage(image, file.pos_in_image.x, file.pos_in_image.y, imageWidth, imageHeight);
             resolve()
           }).catch(e => {
             console.log("decode failed because of DOMException, lets try directly");
             console.log(e);
-            canvas.drawImage(image, file.pos_in_image.x, file.pos_in_image.y);
+            canvas.drawImage(image, file.pos_in_image.x, file.pos_in_image.y, imageWidth, imageHeight);
             resolve()
           });
       });

--- a/ddimport.js
+++ b/ddimport.js
@@ -259,9 +259,6 @@ class DDImporter extends Application
         //placement math done.
         //Now use the image direct, in case of only one image and no conversion required
         var image_type = '?'
-        if (files.length == 1){
-          image_type = DDImporter.getImageType(atob(files[0].image.substr(0,8)));
-        }
 
         // This code works for both single files and multiple files and supports resizing during scene generation
         // Use a canvas to place the image in case we need to convert something

--- a/importer.html
+++ b/importer.html
@@ -18,6 +18,15 @@
     <input type="checkbox" name="convert-to-webp" {{#if webpConversion}}checked{{/if}}>
   </div>
 
+  <div class="form-group import convert-section" title="You can set a custom Grid PPI value at time of import to change the resolution of the generated image">
+    <label class="import-options">Set Custom Grid PPI <i class="far fa-question-circle"></i></label>
+    <input type="checkbox" class="use-custom-gridPPI" name="use-custom-gridPPI" {{#if useCustomPixelsPerGrid}}checked{{/if}}>
+    <div class="custom-gridPPI-section" name="custom-gridPPI-section" style="display: none">
+      <label class="import-options">Custom Grid PPI (between 50 and 256)</label>
+      <input class="customGridPPIInput" type='number' name="customGridPPI" value="{{defaultCustomPixelsPerGrid}}" min="50" max="256" />
+    </div>
+  </div>
+
   <div class="form-group import" title="This is where the image is uploaded. Your path should be relative to your User Data folder. e.g. worlds/yourworld/maps">
     <label class="import-options">Upload Path <i class="far fa-question-circle"></i></label>
     <input class= "path-input" type='text' name="path" value="{{path}}" />
@@ -40,7 +49,7 @@
     <label class="import-options">Object Walls <i class="far fa-question-circle"></i></label>
     <input type="checkbox" name="object-walls" checked>
   </div>
-  
+
   <div class="form-group import">
     <label class="import-options">Padding</label>
     <div style="display:flex">


### PR DESCRIPTION
Adds support for properly generating images when the pixels_per_grid value has been modified in the .dd2vtt file. Fixes #107.

ALSO adds a new UI feature to declare a custom grid size at time of import - no modification to the .dd2vtt file needed. Check the box, enter the desired grid size in the text field that appears, and the importer will scale both the scene and the generated image to the appropriate size based on the custom grid size.

This has been tested with both single-file import and multi-file import, both when converting to .webp and retaining original image file types, both when increasing and decreasing custom grid size.